### PR TITLE
refactor for deprecated arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_tfe"></a> [tfe](#requirement\_tfe) | >=0.30.0 |
+| <a name="requirement_tfe"></a> [tfe](#requirement\_tfe) | ~>0.33.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | 0.32.1 |
+| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | 0.33.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | 0.7.2 |
 
 ## Modules
@@ -24,6 +24,7 @@ No modules.
 |------|------|
 | [tfe_variable.var](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/variable) | resource |
 | [tfe_variable_set.set](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/variable_set) | resource |
+| [tfe_workspace_variable_set.set](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace_variable_set) | resource |
 | [time_sleep.create](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [tfe_organization.org](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/organization) | data source |
 | [tfe_variable_set.set](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/data-sources/variable_set) | data source |

--- a/main.tf
+++ b/main.tf
@@ -30,11 +30,16 @@ resource "tfe_variable" "var" {
 }
 
 resource "tfe_variable_set" "set" {
-  count         = var.create_variable_set ? 1 : 0
-  name          = var.variable_set_name
-  description   = var.variable_set_description
-  organization  = data.tfe_organization.org.name
-  workspace_ids = values(data.tfe_workspace_ids.ws[0].ids)
+  count        = var.create_variable_set ? 1 : 0
+  name         = var.variable_set_name
+  description  = var.variable_set_description
+  organization = data.tfe_organization.org.name
+}
+
+resource "tfe_workspace_variable_set" "set" {
+  for_each        = data.tfe_workspace_ids.ws[0].ids
+  variable_set_id = var.create_variable_set ? tfe_variable_set.set[0].id : data.tfe_variable_set.set[0].id
+  workspace_id    = each.value
 }
 
 data "tfe_variable_set" "set" {

--- a/providers.tf
+++ b/providers.tf
@@ -2,7 +2,7 @@ terraform {
   experiments = [module_variable_optional_attrs]
   required_providers {
     tfe = {
-      version = ">=0.30.0"
+      version = "~>0.33.0"
     }
   }
 }


### PR DESCRIPTION
Updated the module to support the new `tfe_workspace_variable_set` resource
Removed the `workspace_ids` from the `tfe_variable_set` resource as this has been deprecated.